### PR TITLE
Fix build with Java 8 javadoc tool

### DIFF
--- a/src/main/java/io/blueocean/rest/pipeline/editor/ExportedDescribableModel.java
+++ b/src/main/java/io/blueocean/rest/pipeline/editor/ExportedDescribableModel.java
@@ -42,7 +42,7 @@ public class ExportedDescribableModel {
     }
 
     /**
-     * The Java class name for this describable (since we can't seem to export a Class<?>...)
+     * The Java class name for this describable (since we can't seem to export a Class&lt;?&gt; ...)
      * See {@link DescribableModel#getType()}
      */
     @Exported


### PR DESCRIPTION
There's still some warnings that would be better to fix to reduce noise,
but only fixing the "error" to be able to build without disabling the
javadoc plugin.

@reviewbybees