### PR TITLE
Release 0.7 was busted, had to spin a new 0.7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
         <node.version>5.8.0</node.version>
         <npm.version>3.7.3</npm.version>
         <blueocean.version>1.0.0-b13-SNAPSHOT</blueocean.version>
-        <declarative.version>0.7</declarative.version>
+        <declarative.version>0.7.1</declarative.version>
     </properties>
 
     <repositories>


### PR DESCRIPTION
cc @reviewbybees esp @kzantow 

And @i386, *this* release (0.7.1) should be used in BO proper.