### PR TITLE
[FIX JENKINS-40242] preserve unknown sections

### DIFF
--- a/src/main/js/components/editor/EditorMain.jsx
+++ b/src/main/js/components/editor/EditorMain.jsx
@@ -120,17 +120,25 @@ export class EditorMain extends Component<DefaultProps, Props, State> {
         this.setState({selectedStep});
     }
 
-    stepDataChanged(newValue:any) {
-
-        const {selectedStep} = this.state;
+    stepDataChanged(newStep:any) {
+        const {selectedStage,selectedStep} = this.state;
 
         if (!selectedStep) {
             console.log("unable to set new step data, no currently selected step");
             return;
         }
-        selectedStep.data = newValue;
+
+        const parentStep = pipelineStore.findParentStep(selectedStep);
+        const stepArray = (parentStep && parentStep.children) || selectedStage.steps;
+        let idx = 0;
+        for (; idx < stepArray.length; idx++) {
+            if (stepArray[idx].id === selectedStep.id) {
+                break;
+            }
+        }
+        stepArray[idx] = newStep;
         this.setState({
-            selectedStep: selectedStep
+            selectedStep: newStep
         });
     }
 

--- a/src/main/js/components/editor/EditorStepDetails.jsx
+++ b/src/main/js/components/editor/EditorStepDetails.jsx
@@ -3,7 +3,8 @@
 import React, {Component, PropTypes} from 'react';
 import pipelineStepListStore from '../../services/PipelineStepListStore';
 import type {StepInfo} from './common';
-import GenericEditor from './steps/GenericStepEditor';
+import GenericStepEditor from './steps/GenericStepEditor';
+import UnknownStepEditor from './steps/UnknownStepEditor';
 
 const allStepEditors = [
     require('./steps/ShellScriptStepEditor').default,
@@ -51,7 +52,7 @@ export class EditorStepDetails extends Component {
     commitValue(step) {
         const {onDataChange} = this.props;
         if (onDataChange) {
-            onDataChange(step.data);
+            onDataChange(step);
         }
     }
 
@@ -70,7 +71,15 @@ export class EditorStepDetails extends Component {
         if (editor) {
             return editor;
         }
-        return GenericEditor;
+        if (!this.state.stepMetadata) {
+            return null;
+        }
+
+        const foundMeta = this.state.stepMetadata.filter(md => md.functionName === step.name);
+        if (foundMeta.length === 0) {
+            return UnknownStepEditor;
+        }
+        return GenericStepEditor;
     }
 
     render() {

--- a/src/main/js/components/editor/steps/UnknownStepEditor.jsx
+++ b/src/main/js/components/editor/steps/UnknownStepEditor.jsx
@@ -1,0 +1,56 @@
+// @flow
+
+import React, { Component, PropTypes } from 'react';
+import debounce from 'lodash.debounce';
+import { TextInput } from '@jenkins-cd/design-language';
+import { convertPipelineStepsToJson, convertJsonStepsToPipeline, convertStepsToJson, convertStepFromJson } from '../../../services/PipelineSyntaxConverter';
+import type { PipelineStep } from '../../../services/PipelineSyntaxConverter';
+
+type Props = {
+    onChange: Function,
+    step: any,
+}
+
+type State = {
+    stepScript: Array<any>,
+};
+
+type DefaultProps = typeof UnknownStepEditorPanel.defaultProps;
+
+export default class UnknownStepEditorPanel extends Component<DefaultProps, Props, State> {
+    props:Props;
+    state:State;
+
+    constructor(props:Props) {
+        super(props);
+        this.state = { stepScript: null };
+    }
+
+    componentWillMount() {
+        convertJsonStepsToPipeline(convertStepsToJson([this.props.step]), stepScript => {
+            this.setState({stepScript: stepScript});
+        });
+    }
+
+    updateStepData = debounce(stepScript => {
+        this.setState({stepScript: stepScript});
+        convertPipelineStepsToJson(stepScript, (stepJson, errors) => {
+            const newStep = convertStepFromJson(stepJson[0]);
+            newStep.id = this.props.step.id;
+            this.props.onChange(newStep);
+        });
+    }, 300);
+
+    render() {
+        const { step } = this.props;
+        const { stepScript } = this.state;
+
+        if (!step || !stepScript) {
+            return null;
+        }
+
+        return (<textarea className="editor-step-detail-script"
+                  defaultValue={stepScript}
+                  onChange={(e) => this.updateStepData(e.target.value)} />);
+    }
+}

--- a/src/main/js/services/PipelineStore.js
+++ b/src/main/js/services/PipelineStore.js
@@ -6,7 +6,7 @@
 export type StageInfo = {
     name: string,
     id: number,
-    children: StageInfo[],
+    children: Array<StageInfo|UnknownSection>,
     steps: StepInfo[],
 };
 
@@ -25,6 +25,15 @@ export type StepInfo = {
 export type PipelineInfo = StageInfo & {
     agent: StepInfo,
 };
+
+export class UnknownSection {
+    prop: string;
+    json: any;
+    constructor(prop: string, json: any) {
+        this.prop = prop;
+        this.json = json;
+    }
+}
 
 function _copy<T>(obj: T): ?T {
     if (!obj) {


### PR DESCRIPTION
This enables preservation of unknown sections within a pipeline script and handling unknown steps by converting to a pipeline script editor.

In order to test, use a pipeline script that contains sections not currently handled by the editor, such as `parameters`, and steps not currently available such as `randomStep`. Here's a sample Pipeline:

```
pipeline {
  agent none
  parameters {
    booleanParam(defaultValue: true, description: '', name: 'flag')
  }
  stages {
    stage('foo') {
      steps {
        echo(message: 'hello')
        randomStep(randomArg: 'randomValue')
      }
    }
  }
}
```

Ensure the pipeline load/save returns an equivalent pipeline script without modification and that the unknown step provides a pipeline script editor (a textbox currently) and exports properly.

Check it:

[![See it in action](https://img.youtube.com/vi/dlzg1TfsmYM/0.jpg)](https://www.youtube.com/watch?v=dlzg1TfsmYM)