### PR TITLE
Centralize id generator for pipeline nodes

### DIFF
--- a/src/main/js/services/IdGenerator.js
+++ b/src/main/js/services/IdGenerator.js
@@ -1,0 +1,14 @@
+/**
+ * Creates a "unique" id generator
+ */
+
+export type IdGenerator = {
+    next(): number;
+};
+
+const idgen: IdGenerator = {
+    id: 0,
+    next() { return --this.id; }
+};
+
+export default idgen;

--- a/src/main/js/services/PipelineStore.js
+++ b/src/main/js/services/PipelineStore.js
@@ -1,5 +1,7 @@
 // @flow
 
+import idgen from './IdGenerator';
+
 /**
  * A stage in a pipeline
  */
@@ -43,12 +45,10 @@ function _copy<T>(obj: T): ?T {
     return JSON.parse(JSON.stringify(obj));
 }
 
-let idSeq = -11111;
-
 function createBasicStage(name:string):StageInfo {
     return {
         name,
-        id: idSeq--,
+        id: idgen.next(),
         children: [],
         steps: [],
     };
@@ -258,7 +258,7 @@ class PipelineStore {
         let newStepsForStage = oldStepsForStage;
 
         let newStep:StepInfo = {
-            id: --idSeq,
+            id: idgen.next(),
             isContainer: step.isBlockContainer,
             children: [],
             name: step.functionName,

--- a/src/main/js/services/PipelineSyntaxConverter.js
+++ b/src/main/js/services/PipelineSyntaxConverter.js
@@ -4,6 +4,7 @@ import { Fetch, UrlConfig } from '@jenkins-cd/blueocean-core-js';
 import { UnknownSection } from './PipelineStore';
 import type { PipelineInfo, StageInfo, StepInfo } from './PipelineStore';
 import pipelineStepListStore from './PipelineStepListStore';
+import idgen from './IdGenerator';
 
 const value = 'value';
 
@@ -38,8 +39,6 @@ export type PipelineStage = {
     agent?: PipelineValueDescriptor,
     steps?: PipelineStep[],
 };
-
-const idgen = { id: 0, next() { return --this.id; } };
 
 function singleValue(v: any) {
     if (Array.isArray(v)) {


### PR DESCRIPTION
No ticket for this, just needed to fix the id generation between `PipelineStore` and `PipelineSyntaxConverter`.

@reviewbybees cc/ @sophistifunk 