### PR TITLE
[FIX JENKINS-40199] Tool listing API

### DIFF
--- a/src/main/java/io/blueocean/rest/pipeline/editor/ExportedToolDescriptor.java
+++ b/src/main/java/io/blueocean/rest/pipeline/editor/ExportedToolDescriptor.java
@@ -1,0 +1,93 @@
+/*
+ * The MIT License
+ *
+ * Copyright (c) 2016, CloudBees, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package io.blueocean.rest.pipeline.editor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.kohsuke.stapler.export.Exported;
+import org.kohsuke.stapler.export.ExportedBean;
+
+/**
+ * Provides tool information
+ */
+@ExportedBean
+public class ExportedToolDescriptor {
+    private final String toolName;
+    private final String symbol;
+    private final Class<?> type;
+    private final List<ExportedToolInstallation> installations = new ArrayList<ExportedToolInstallation>();
+
+    public ExportedToolDescriptor(String toolName, String symbol, Class<?> type) {
+        this.toolName = toolName;
+        this.symbol = symbol;
+        this.type = type;
+    }
+    
+    @Exported
+    public String getToolName() {
+        return toolName;
+    }
+    
+    @Exported
+    public String getSymbol() {
+        return symbol;
+    }
+    
+    @Exported
+    public String getType() {
+        return type.getName();
+    }
+    
+    @Exported
+    public ExportedToolInstallation[] getInstallations() {
+        return installations.toArray(new ExportedToolInstallation[installations.size()]);
+    }
+    
+    public void addInstallation(ExportedToolInstallation installation) {
+        this.installations.add(installation);
+    }
+    
+    @ExportedBean
+    public static class ExportedToolInstallation {
+        private final String name;
+        private final Class<?> type;
+        
+        public ExportedToolInstallation(String name, Class<?> type) {
+            this.name = name;
+            this.type = type;
+        }
+        
+        @Exported
+        public String getName() {
+            return name;
+        }
+        
+        @Exported
+        public String getType() {
+            return type.getName();
+        }
+    }
+}

--- a/src/main/java/io/blueocean/rest/pipeline/editor/PipelineMetadataService.java
+++ b/src/main/java/io/blueocean/rest/pipeline/editor/PipelineMetadataService.java
@@ -12,6 +12,8 @@ import hudson.Launcher;
 import hudson.model.Describable;
 import hudson.tasks.Builder;
 import hudson.tasks.Publisher;
+import hudson.tools.ToolDescriptor;
+import hudson.tools.ToolInstallation;
 import jenkins.tasks.SimpleBuildStep;
 import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgent;
 import org.jenkinsci.plugins.pipeline.modeldefinition.agent.DeclarativeAgentDescriptor;
@@ -22,7 +24,6 @@ import org.jenkinsci.plugins.structs.describable.DescribableModel;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
 import org.kohsuke.stapler.NoStaplerConstructorException;
-import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.verb.GET;
 
 import hudson.Extension;
@@ -73,6 +74,24 @@ public class PipelineMetadataService implements ApiRoutable {
             }
         }
         return models.toArray(new ExportedDescribableModel[models.size()]);
+    }
+
+    /**
+     * Function to return all {@link ExportedToolDescriptor}s present in the system when accessed through the REST API,
+     * pipeline scripts need: symbol and name to specify tools
+     */
+    @GET
+    @TreeResponse
+    public ExportedToolDescriptor[] doToolMetadata() {
+        List<ExportedToolDescriptor> models = new ArrayList<>();
+        for (ToolDescriptor<? extends ToolInstallation> d : ToolInstallation.all()) {
+            ExportedToolDescriptor descriptor = new ExportedToolDescriptor(d.getDisplayName(), symbolForObject(d), d.getClass());
+            models.add(descriptor);
+            for (ToolInstallation installation : d.getInstallations()) {
+                descriptor.addInstallation(new ExportedToolDescriptor.ExportedToolInstallation(installation.getName(), installation.getClass()));
+            }
+        }
+        return models.toArray(new ExportedToolDescriptor[models.size()]);
     }
 
     /**

--- a/src/main/js/services/IdGenerator.js
+++ b/src/main/js/services/IdGenerator.js
@@ -1,0 +1,14 @@
+/**
+ * Creates a "unique" id generator
+ */
+
+export type IdGenerator = {
+    next(): number;
+};
+
+const idgen: IdGenerator = {
+    id: 0,
+    next() { return --this.id; }
+};
+
+export default idgen;

--- a/src/main/js/services/PipelineStore.js
+++ b/src/main/js/services/PipelineStore.js
@@ -1,5 +1,7 @@
 // @flow
 
+import idgen from './IdGenerator';
+
 /**
  * A stage in a pipeline
  */
@@ -43,12 +45,10 @@ function _copy<T>(obj: T): ?T {
     return JSON.parse(JSON.stringify(obj));
 }
 
-let idSeq = -11111;
-
 function createBasicStage(name:string):StageInfo {
     return {
         name,
-        id: idSeq--,
+        id: idgen.next(),
         children: [],
         steps: [],
     };
@@ -258,7 +258,7 @@ class PipelineStore {
         let newStepsForStage = oldStepsForStage;
 
         let newStep:StepInfo = {
-            id: --idSeq,
+            id: idgen.next(),
             isContainer: step.isBlockContainer,
             children: [],
             name: step.functionName,

--- a/src/main/js/services/PipelineSyntaxConverter.js
+++ b/src/main/js/services/PipelineSyntaxConverter.js
@@ -4,6 +4,7 @@ import { Fetch, UrlConfig } from '@jenkins-cd/blueocean-core-js';
 import { UnknownSection } from './PipelineStore';
 import type { PipelineInfo, StageInfo, StepInfo } from './PipelineStore';
 import pipelineStepListStore from './PipelineStepListStore';
+import idgen from './IdGenerator';
 
 const value = 'value';
 
@@ -38,8 +39,6 @@ export type PipelineStage = {
     agent?: PipelineValueDescriptor,
     steps?: PipelineStep[],
 };
-
-const idgen = { id: 0, next() { return --this.id; } };
 
 function singleValue(v: any) {
     if (Array.isArray(v)) {

--- a/src/test/java/io/blueocean/rest/pipeline/editor/PipelineMetadataServiceTest.java
+++ b/src/test/java/io/blueocean/rest/pipeline/editor/PipelineMetadataServiceTest.java
@@ -12,6 +12,7 @@ import org.junit.Test;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.JSONWebResponse;
 
+import hudson.model.JDK;
 import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 
@@ -71,6 +72,28 @@ public class PipelineMetadataServiceTest {
         assertTrue(m.getHasSingleRequiredParameter());
 
         assertEquals(3, m.getParameters().size());
+    }
+
+    @Test
+    public void toolMetadata() throws Exception {
+        PipelineMetadataService svc = new PipelineMetadataService();
+
+        List<ExportedToolDescriptor> tools = new ArrayList<>();
+        tools.addAll(Arrays.asList(svc.doToolMetadata()));
+
+        assertFalse(tools.isEmpty());
+
+        ExportedToolDescriptor t = null;
+
+        for (ExportedToolDescriptor a : tools) {
+            if (a.getType().equals(JDK.DescriptorImpl.class.getName())) {
+                t = a;
+            }
+        }
+
+        assertNotNull(t);
+
+        assertEquals("jdk", t.getSymbol());
     }
 
     @Test


### PR DESCRIPTION
NOTE: this is the only relevant commit: 3bc4e84 

API to list tools available. In order to use them from Pipeline Model Definition, we need the tool symbol and the name of the specific installation. Example is like this:

```
{
    "_class" : "io.blueocean.rest.pipeline.editor.ExportedToolDescriptor",
    "installations" : [
      {
        "name" : "JDK8",
        "type" : "hudson.model.JDK"
      }
    ],
    "symbol" : "jdk",
    "toolName" : "JDK",
    "type" : "hudson.model.JDK$DescriptorImpl"
  },
```

@reviewbybees esp. @abayer 