### PR TITLE
Story/jenkins 42791 editor prompt GitHub token

### DIFF
--- a/src/main/js/EditorPage.jsx
+++ b/src/main/js/EditorPage.jsx
@@ -184,7 +184,7 @@ class PipelineLoader extends React.Component {
         this.forceUpdate();
     }
 
-    showLoadingError() {
+    showLoadingError(err) {
         this.showErrorDialog(
             <div className="errors">
                 <div>

--- a/src/main/js/EditorPage.jsx
+++ b/src/main/js/EditorPage.jsx
@@ -427,7 +427,7 @@ class PipelineLoader extends React.Component {
 
         this.loadContent(internal => {
             pipelineStore.setPipeline(internal);
-            this.setState({dialog: null})
+            this.setState({dialog: null});
         });
     }
     

--- a/src/main/js/EditorPage.jsx
+++ b/src/main/js/EditorPage.jsx
@@ -437,7 +437,11 @@ class PipelineLoader extends React.Component {
                     sha: this.state.sha,
                     message: saveMessage,
                     content: pipelineScript,
-                })
+                };
+
+                // TODO: building the body so we can pass it down is a little awkward
+                const body = this.contentApi.buildSaveContentRequest(saveParams);
+                this.contentApi.saveContent(saveParams)
                 .then(data => {
                     this.pipelineIsModified = false;
                     this.lastPipeline = JSON.stringify(convertInternalModelToJson(pipelineStore.pipeline));

--- a/src/main/js/EditorPage.jsx
+++ b/src/main/js/EditorPage.jsx
@@ -385,10 +385,6 @@ class PipelineLoader extends React.Component {
         )});
     }
 
-    checkForToken() {
-        this.createTokenDialog({loading: true});
-    }
-
     createTokenDialog({loading = false } = {}) {
         const pipeline = pipelineService.getPipeline(this.href);
         const { scmSource } = pipeline;

--- a/src/main/js/EditorPage.jsx
+++ b/src/main/js/EditorPage.jsx
@@ -241,7 +241,7 @@ class PipelineLoader extends React.Component {
             const team = split[0];
             const repo = split.length > 1 ? split[1] : team;
             const { id: scmId, apiUrl } = this.state.scmSource;
-            // TODO: bitbucket isn't passing the pipeline as "orgname/reponame" so this request 404's
+            // TODO: bitbucket isn't passing the pipeline in "orgname/reponame" format so this request 404's with bogus team name
             let repositoryUrl = `${getRestUrl({organization})}scm/${scmId}/organizations/${team}/repositories/${repo}/`;
             if (apiUrl) {
                 repositoryUrl += `?apiUrl=${apiUrl}`;
@@ -399,6 +399,7 @@ class PipelineLoader extends React.Component {
         // hide the dialog until it reports as ready (i.e. credential fetch is done)
         const dialogClassName = `dialog-token ${loading ? 'loading' : ''}`;
 
+        // TODO: variable title
         this.setState({
             dialog: (
                 <Dialog

--- a/src/main/js/SaveApi.js
+++ b/src/main/js/SaveApi.js
@@ -1,17 +1,17 @@
 // @flow
 
-import { Fetch, getRestUrl, sseService, loadingIndicator, capabilityAugmenter } from '@jenkins-cd/blueocean-core-js';
+import { Fetch, getRestUrl, sseService, loadingIndicator } from '@jenkins-cd/blueocean-core-js';
 
 export class SaveApi {
 
-    indexRepo(organization, teamName, repoName, apiUrl, credentialId) {
+    indexRepo(organization, teamName, repoName, scmId, apiUrl) {
         const createUrl = `${getRestUrl({organization})}/pipelines/`;
 
         const requestBody = {
             name: teamName,
             $class: 'io.jenkins.blueocean.blueocean_github_pipeline.GithubPipelineCreateRequest',
             scmConfig: {
-                credentialId,
+                id: scmId,
                 uri: apiUrl,
                 config: {
                     orgName: teamName,

--- a/src/main/js/SaveApi.js
+++ b/src/main/js/SaveApi.js
@@ -1,18 +1,18 @@
 // @flow
 
-import { action, computed, observable } from 'mobx';
 import { Fetch, getRestUrl, sseService, loadingIndicator, capabilityAugmenter } from '@jenkins-cd/blueocean-core-js';
 
 export class SaveApi {
 
-    indexRepo(organization, teamName, repoName) {
+    indexRepo(organization, teamName, repoName, apiUrl, credentialId) {
         const createUrl = `${getRestUrl({organization})}/pipelines/`;
 
         const requestBody = {
             name: teamName,
             $class: 'io.jenkins.blueocean.blueocean_github_pipeline.GithubPipelineCreateRequest',
             scmConfig: {
-                uri: 'https://api.github.com',
+                credentialId,
+                uri: apiUrl,
                 config: {
                     orgName: teamName,
                     repos: [repoName],
@@ -28,11 +28,10 @@ export class SaveApi {
             body: JSON.stringify(requestBody),
         };
 
-        return Fetch.fetchJSON(createUrl, { fetchOptions })
-            .then(pipeline => capabilityAugmenter.augmentCapabilities(pipeline));
+        return Fetch.fetchJSON(createUrl, { fetchOptions });
     }
 
-    index(organization, folder, repo, complete, onError, progress) {
+    index(organization, folder, repo, apiUrl, credentialId, complete, onError, progress) {
         const cleanup = err => {
             sseService.removeHandler(sseId);
             clearTimeout(timeoutId);
@@ -59,7 +58,7 @@ export class SaveApi {
             }
         });
 
-        this.indexRepo(organization, folder, repo);
+        this.indexRepo(organization, folder, repo, apiUrl, credentialId);
     }
 }
 

--- a/src/main/js/api/ScmContentApi.js
+++ b/src/main/js/api/ScmContentApi.js
@@ -35,7 +35,7 @@ class ScmContentApi {
 
         if (status === 404) {
             throw new TypedError(LoadError.JENKINSFILE_NOT_FOUND, responseBody);
-        } else if (message.indexOf('accessToken not found') !== -1) {
+        } else if (message.indexOf('accessToken not found') !== -1 || message.indexOf('no credentials with github accessToken found') !== -1) {
             throw new TypedError(LoadError.TOKEN_NOT_FOUND, responseBody);
         } else if (message.indexOf('Invalid accessToken') !== -1) {
             throw new TypedError(LoadError.TOKEN_REVOKED, responseBody);

--- a/src/main/js/api/ScmContentApi.js
+++ b/src/main/js/api/ScmContentApi.js
@@ -21,8 +21,10 @@ export const LoadError = {
 class ScmContentApi {
 
     loadContent({organization, pipeline, branch, path = 'Jenkinsfile'}) {
-        const contentUrl = `${getRestUrl({ organization, pipeline })}scm/content?branch=${encodeURIComponent(branch)}&path=${path}`;
-
+        let contentUrl = `${getRestUrl({ organization, pipeline })}scm/content?path=${path}`;
+        if (branch) {
+            contentUrl += `&branch=${encodeURIComponent(branch)}`;
+        }
         return Fetch.fetchJSON(contentUrl)
             .then(result => result)
             .catch(error => this._loadContentErrorHandler(error));

--- a/src/main/js/api/ScmContentApi.js
+++ b/src/main/js/api/ScmContentApi.js
@@ -1,0 +1,76 @@
+import { Fetch, getRestUrl } from '@jenkins-cd/blueocean-core-js';
+import TypedError from './TypedError';
+
+
+const Base64 = {
+    encode: (data) => btoa(data),
+    decode: (str) => atob(str),
+};
+
+export const LoadError = {
+    TOKEN_NOT_FOUND: 'TOKEN_NOT_FOUND',
+    TOKEN_REVOKED: 'TOKEN_REVOKED',
+    TOKEN_INVALID_SCOPES: 'TOKEN_INVALID_SCOPES',
+    JENKINSFILE_NOT_FOUND: 'JENKINSFILE_NOT_FOUND',
+};
+
+
+/**
+ * Load and save content to a pipeline's backing SCM provider.
+ */
+class ScmContentApi {
+
+    loadContent({organization, pipeline, branch, path = 'Jenkinsfile'}) {
+        const contentUrl = `${getRestUrl({ organization, pipeline })}scm/content?branch=${encodeURIComponent(branch)}&path=${path}`;
+
+        return Fetch.fetchJSON(contentUrl)
+            .then(result => result)
+            .catch(error => this._loadContentErrorHandler(error));
+    }
+
+    _loadContentErrorHandler(error) {
+        const { status } = error.response;
+        const { responseBody } = error;
+        const { message } = responseBody;
+
+        if (status === 404) {
+            throw new TypedError(LoadError.JENKINSFILE_NOT_FOUND, responseBody);
+        } else if (message.indexOf('accessToken not found') !== -1) {
+            throw new TypedError(LoadError.TOKEN_NOT_FOUND, responseBody);
+        } else if (message.indexOf('Invalid accessToken') !== -1) {
+            throw new TypedError(LoadError.TOKEN_REVOKED, responseBody);
+        }
+
+        // TODO: TOKEN_INVALID_SCOPES
+
+        throw error;
+    }
+
+    saveContent({organization, pipeline, repo, sourceBranch, targetBranch, sha, message, path = 'Jenkinsfile', content}) {
+        const contentUrl = `${getRestUrl({organization, pipeline})}scm/content/`;
+
+        const body = {
+            content: {
+                message,
+                path,
+                branch: targetBranch,
+                sourceBranch,
+                repo,
+                sha,
+                base64Data: Base64.encode(content),
+            }
+        };
+
+        const fetchOptions = {
+            method: 'PUT',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(body),
+        };
+
+        return Fetch.fetchJSON(contentUrl, { fetchOptions });
+    }
+
+}
+
+
+export default ScmContentApi;

--- a/src/main/js/api/ScmContentApi.js
+++ b/src/main/js/api/ScmContentApi.js
@@ -37,7 +37,7 @@ class ScmContentApi {
 
         if (status === 404) {
             throw new TypedError(LoadError.JENKINSFILE_NOT_FOUND, responseBody);
-        } else if (message.indexOf('accessToken not found') !== -1 || message.indexOf('no credentials with github accessToken found') !== -1) {
+        } else if (status === 428) {
             throw new TypedError(LoadError.TOKEN_NOT_FOUND, responseBody);
         } else if (message.indexOf('Invalid accessToken') !== -1) {
             throw new TypedError(LoadError.TOKEN_REVOKED, responseBody);

--- a/src/main/js/api/ScmContentApi.js
+++ b/src/main/js/api/ScmContentApi.js
@@ -46,10 +46,8 @@ class ScmContentApi {
         throw error;
     }
 
-    saveContent({organization, pipeline, repo, sourceBranch, targetBranch, sha, message, path = 'Jenkinsfile', content}) {
-        const contentUrl = `${getRestUrl({organization, pipeline})}scm/content/`;
-
-        const body = {
+    buildSaveContentRequest({organization, pipeline, repo, sourceBranch, targetBranch, sha, message, path = 'Jenkinsfile', content}) {
+        return {
             content: {
                 message,
                 path,
@@ -60,6 +58,14 @@ class ScmContentApi {
                 base64Data: Base64.encode(content),
             }
         };
+    }
+
+    saveContent({organization, pipeline, repo, sourceBranch, targetBranch, sha, message, path = 'Jenkinsfile', content}) {
+        const contentUrl = `${getRestUrl({organization, pipeline})}scm/content/`;
+
+        const body = this.buildSaveContentRequest({
+            organization, pipeline, repo, sourceBranch, targetBranch, sha, message, path, content,
+        });
 
         const fetchOptions = {
             method: 'PUT',

--- a/src/main/js/api/TypedError.js
+++ b/src/main/js/api/TypedError.js
@@ -1,0 +1,15 @@
+/**
+ * Utlity class for "typing" of server errors
+ */
+class TypedError {
+
+    constructor(type, serverError) {
+        this.type = type;
+        this.code = serverError.code;
+        this.message = serverError.message;
+        this.errors = serverError.errors;
+    }
+
+}
+
+export default TypedError;

--- a/src/main/less/editor.less
+++ b/src/main/less/editor.less
@@ -796,3 +796,19 @@
         }
     }
 }
+
+.dialog-token {
+    width: 480px;
+
+    .Dialog-content-margin {
+        margin: 32px 40px;
+    }
+
+    .Dialog-button-bar {
+        display: none;
+    }
+
+    &.loading {
+        display: none;
+    }
+}

--- a/src/main/less/editor.less
+++ b/src/main/less/editor.less
@@ -811,4 +811,14 @@
     &.loading {
         display: none;
     }
+
+    .credentials-picker-github {
+        > .FormElement .FormElement-children {
+            flex-direction: column;
+
+            .button-connect {
+                margin: 1em 0 0 0;
+            }
+        }
+    }
 }

--- a/src/main/less/editor.less
+++ b/src/main/less/editor.less
@@ -812,7 +812,7 @@
         display: none;
     }
 
-    .credentials-picker-github {
+    .credentials-picker-github, .credentials-picker-github-enterprise {
         > .FormElement .FormElement-children {
             flex-direction: column;
 


### PR DESCRIPTION
# Description
- See [JENKINS-42791](https://issues.jenkins-ci.org/browse/JENKINS-42791).
- Needs to be built along with jenkinsci/blueocean-plugin#1276 so some SCM metadata about the pipeline will be exposed (for proper credentials integration).
- This PR does two major things
   - Utilizes the new "jenkins.credentials.selection" XP to display the GitHub credentials dialog if the user has no token registered. This should work for both GitHub Cloud and Enterprise.
   - Fixes an issue with the Editor when saving GHE pipelines: the JF would save ok but sometimes the indexing would fail.
- I really haven't had time to test this as much as I'd like, but I wanted to get a PR up for feedback since I am out next week. I did verify the "conflict" error handling is working... I'm sure @kzantow knows of some use cases that are tricky which I may have missed.

# Submitter checklist
- [x] Link to JIRA ticket in description, if appropriate.
- [x] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

