### PR TITLE
Fixes regression for empty org folder for github

### DIFF
--- a/src/main/js/EditorPage.jsx
+++ b/src/main/js/EditorPage.jsx
@@ -119,14 +119,17 @@ class PipelineLoader extends React.Component {
     componentWillMount() {
         pipelineStore.setPipeline(null); // reset any previous loaded pipeline
         const { organization, pipeline } = this.props.params;
-        let href = Paths.rest.pipeline(organization, pipeline);
+        const split = pipeline.split('/');
+        const team = split[0];
+        let href = Paths.rest.pipeline(organization, team);
+
         pipelineService.fetchPipeline(href, { useCache: true })
             .then(pipeline => {
                 if(pipeline.scmSource && pipeline.scmSource.id) {
                     this.setState({ scmId: pipeline.scmSource.id });
                 }
-                this.loadPipeline();
             });
+        this.loadPipeline();
     }
     
     componentDidMount() {

--- a/src/main/js/EditorPage.jsx
+++ b/src/main/js/EditorPage.jsx
@@ -122,14 +122,13 @@ class PipelineLoader extends React.Component {
         const split = pipeline.split('/');
         const team = split[0];
         let href = Paths.rest.pipeline(organization, team);
-
         pipelineService.fetchPipeline(href, { useCache: true })
             .then(pipeline => {
                 if(pipeline.scmSource && pipeline.scmSource.id) {
                     this.setState({ scmId: pipeline.scmSource.id });
                 }
+                this.loadPipeline();
             });
-        this.loadPipeline();
     }
     
     componentDidMount() {


### PR DESCRIPTION
PipelineLoader.loadPipeline() didn't get call for empty org folder. The fix has been verified with blueocean ATH run locally.

# Description

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

