### PR TITLE
fix editor Icon color in run details header

### DIFF
--- a/src/main/js/PipelineEditorLink.jsx
+++ b/src/main/js/PipelineEditorLink.jsx
@@ -25,6 +25,8 @@ class PipelineEditorLink extends React.Component {
         const { run, pipeline } = this.props;
         const pipelinePath = pipeline.fullName.split('/');
         const branch = run ? run.pipeline : pipelinePath[pipelinePath.length - 1];
+        const editIconColor = run ? '#ffffff' : 'rgba(53, 64, 82, 0.25)';
+        const editIconHoverColor = run ? '#ffffff' : '#4a90e2';
         // this shows up in the branches table, each pipeline.fullName includes the branch
         // if it's not on the branches table, branch is in the run
         if (!run) {
@@ -34,7 +36,7 @@ class PipelineEditorLink extends React.Component {
 
         return (
             <Link className="pipeline-editor-link" to={baseUrl} title="Edit">
-                <Icon icon="ImageEdit" size={24} color="rgba(53, 64, 82, 0.25)" hoverColor="#4a90e2" />
+                <Icon icon="ImageEdit" size={24} color={editIconColor} hoverColor={editIconHoverColor} />
             </Link>
         );
     }


### PR DESCRIPTION
# Description

Fixes the editor icon color in the run details header

See [JENKINS-XXXXX](https://issues.jenkins-ci.org/browse/JENKINS-XXXXX).

# Submitter checklist
- [ ] Link to JIRA ticket in description, if appropriate.
- [ ] Change is code complete and matches issue description
- [ ] Appropriate unit or acceptance tests or explanation to why this change has no tests
- [ ] Reviewer's manual test instructions provided in PR description. See Reviewer's first task below.

# Reviewer checklist
- [ ] Run the changes and verified the change matches the issue description
- [ ] Reviewed the code
- [ ] Verified that the appropriate tests have been written or valid explanation given

